### PR TITLE
Add Viverse SDK versioning and change log

### DIFF
--- a/DeveloperTools/CHANGELOG.md
+++ b/DeveloperTools/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+## v1.2.9 (2025-05-29)
+
+SDK Path: [https://www.viverse.com/static-assets/viverse-sdk/1.2.9/viverse-sdk.umd.js](https://www.viverse.com/static-assets/viverse-sdk/1.2.9/viverse-sdk.umd.js)
+
+**Changed**
+
+- Revise logic for checking checkAuth postMessage
+
+## v1.2.8 (2025-05-28)
+
+SDK Path: [https://www.viverse.com/static-assets/viverse-sdk/1.2.8/viverse-sdk.umd.js](https://www.viverse.com/static-assets/viverse-sdk/1.2.8/viverse-sdk.umd.js)
+
+**Added**
+
+- viverse-sdk for standalone app authenticate flow
+- Play SDK

--- a/DeveloperTools/README.md
+++ b/DeveloperTools/README.md
@@ -18,6 +18,12 @@ While we do not require developers use these tools — and while we also make it
 
 <table><thead><tr><th width="158.1304931640625">Name</th><th width="332.62384033203125">Description</th><th width="171.2432861328125">Cost to Developer</th></tr></thead><tbody><tr><td><a href="login-and-authentication-for-the-sdk.md">Login &#x26; Authentication</a> [Beta]</td><td>Get a user's account information when they join your experience on VIVERSE. This will allow you to access their display name, avatar information, and account information, making it easier for end-users to travel between VIVERSE experiences while staying connected to their identity and friends.</td><td>Free!</td></tr><tr><td><a href="avatar-sdk.md">Avatar SDK</a> [Beta]</td><td>Download and use a user's avatar file in your VIVERSE experience. Digital identity is an important consideration in 3D and including end-users' avatars makes them feel more at home in your VIVERSE World.</td><td>Free!</td></tr><tr><td><a href="leaderboard-sdk.md">Leaderboard SDK</a> [Beta]</td><td>Access and save information about players interacting with your world. Keep track of high scores to boost engagement with your player base.</td><td>Free!</td></tr><tr><td><a href="matchmaking-and-networking-sdk.md">Matchmaking &#x26; Networking</a> [Beta]</td><td>Save and network game-state between clients in your VIVERSE world. Use this SDK to build richer multiplayer experiences.</td><td>Free!</td></tr></tbody></table>
 
+## SDK Versioning
+
+Latest: [v1.2.9](https://www.viverse.com/static-assets/viverse-sdk/1.2.9/viverse-sdk.umd.js) (2025-05-29)
+
+[Change log](CHANGELOG.md)
+
 ## Provisioning Your Own Game Servers & Services
 
 While the above services are available for free to our developers to use, we frequently allow developers to include their own, externally hosted services in their VIVERSE creations. If you have an API endpoint, database, or hosted gameserver that you would like to access in VIVERSE, please email michael\_morran@htc.com and james\_kane@htc.com OR join our [Discord Server](https://discord.gg/viversecreators) and message us with more information about the nature of your service and the URL you would like whitelisted!

--- a/DeveloperTools/SUMMARY.md
+++ b/DeveloperTools/SUMMARY.md
@@ -5,3 +5,4 @@
 * [Avatar SDK](avatar-sdk.md)
 * [Leaderboard SDK](leaderboard-sdk.md)
 * [Matchmaking & Networking SDK](matchmaking-and-networking-sdk.md)
+* [Change Log](CHANGELOG.md)


### PR DESCRIPTION
Added Viverse SDK versioning information to the [Introduction to Developer Tools](https://github.com/VIVERSE-DOCS/viverse-docs/blob/main/DeveloperTools/README.md) section, included a `CHANGELOG.md` in [SUMMARY.md](https://github.com/VIVERSE-DOCS/viverse-docs/blob/main/DeveloperTools/SUMMARY.md), and documented the changes for the latest two versions.